### PR TITLE
Add downgrade support for people without internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,27 @@ Python3 tool to generate a modified Configuration Dump for a Franklin Wireless R
 ## More Info
 
 Please refer to https://snt.sh/2021/09/rooting-the-t-mobile-t9-franklin-wireless-r717-again/
+
+## No internet instructions
+
+If you don't have internet access (a working sim) on the hotspot, here's a way to get the firmware onto the device.
+
+First, flash the root only image.
+
+Wait for reboot. Connect to hotspot (or use usb to keep your home wifi internet going also, very recommended)
+
+Telnet in with `telnet 192.168.0.1`. 
+Change the root password to something you can remember with `passwd` command, since the change in the root script doesn't seem to work and we need it to ssh in.
+Now you can SSH in, nice since thats better than telnet.
+Now, back on your computer set up a tftp server on your computer. On arch that was just a matter of installing the starting the tftp-hpa package.
+Download this file https://snt.sh/uploads/t9/T9_1311_ota_update_all_block_otas.zip and put it in /srv/tftp ( you may need to chmod the folder or do this as root)
+Also take a copy of the downgrade_no_internet.sh script from this repo
+
+Find out your computers IP that the hotspot gave you (ifconfig works on linux, ipconfig on windows)
+From the hotspot shell, run `tftp tftp forrest@192.168.0.210 -l /cache/ota_update_all.zip -r ota_update_all.zip -g`
+You may need to `touch /cache/ota_update_all.zip` first because tftp is really old and dumb and needs the file to  prexist I guess.
+Do the same thing with my modified script.
+Now just execute the script. You'll need to make it executable first with chmod +x downgrade_no_internet.sh
+
+Piece of cake
+

--- a/src/downgrade_no_internet.sh
+++ b/src/downgrade_no_internet.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -e
+
+#OTA_FILE="https://snt.sh/uploads/t9/T9_891_ota_update_all_block_otas.zip"
+#OTA_SUM="bfd67784c2a21afcdd8de3111cde14fa"
+OTA_SUM="c20f5db25dfa3f5954ff0f9e233d42e4"
+
+# Make sure we are not running yet...
+if [ -f /tmp/.downgrade ]; then
+	echo "Exiting, we are already running!"
+	exit 0
+fi
+
+touch /tmp/.downgrade
+
+mkdir -p /cache/rmagt
+
+echo "Validating downgrade image"
+md5sum /cache/ota_update_all.zip > /tmp/ota_downgrade.md5
+
+if ! grep -q "${OTA_SUM}" /tmp/ota_downgrade.md5; then
+	echo "ERROR, MD5 mismatch! Please retry the downgrade script later."
+	exit 1
+fi
+echo "Downgrade image validated! Continuing with install!"
+
+# Make the OTA system be OK with the abusive install method
+mkdir -p /cache/recovery
+echo "--update_package=/cache/ota_update_all.zip" > /cache/recovery/command
+echo "--debug_no_reboot" >> /cache/recovery/command
+mkdir -p /cache/sec
+echo 1 > /cache/sec/download_verified
+echo 1 > /cache/update_file_verified
+
+# Delete our root tool
+rm /data/configs/root.sh
+
+# Make sure device resets on first boot after OTA
+/usr/bin/set_reset_param.sh
+
+# Reboot into recovery to install
+/usr/bin/go_recovery.sh
+
+# Self nuke
+rm -rf /data/configs/pwn/


### PR DESCRIPTION
This adds a manual method and instructions for users without internet.  Absolutely CRITICAL for those who's SIM will not work UNTIL they downgrade and run some exploits. I'd guess that's a large percentage of people who need this mod.

I think it would be very possible to somehow include the real downgrade firmware bin inside  your bin (bin in bin) so that no internet access is necessary at all. This is just a manual way to hack around it without really improving on your one-click solution. 

This will help the more technical folks, at least. 

Also I realize the instructions are pretty poorly written. I just want you to understand what I did, mostly. Understand if you don't want to merge as is.